### PR TITLE
Fix notify error complaining about missing new_immediate function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2018"
 
 [dependencies]
 glsl-to-spirv = "0.1.7"
-notify = "5.0.0-pre.2"
+notify = "5.0.0-pre.11"
 thiserror = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ where
 
     // Create a watcher for each path.
     let mut watched_paths = vec![];
-    let mut watcher = notify::RecommendedWatcher::new_immediate(move |res| {
+    let mut watcher = notify::RecommendedWatcher::new(move |res| {
         tx.send(res).ok();
     })?;
     for path in paths {


### PR DESCRIPTION
Updated notify dependancy version, RecommendedWatcher::new_immediate() renamed to RecommendedWatcher::new()